### PR TITLE
Add Maven CI workflow with Java 22 temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Maven CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 22
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '22'
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,20 @@
+name: Maven CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 22
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '22'
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
Related to #1

This pull request introduces a GitHub Actions workflow for Maven CI, ensuring that the CI pipeline runs on push or pull request to the main branch using Java 22 temurin.

- **Adds two GitHub Actions workflow files**: 
  - The first file, `maven.yml`, and the second file, `build.yml`, both contain identical configurations to trigger the CI pipeline on push or pull requests to the main branch, set up Java 22 temurin, and run Maven build commands.
  - Both workflows are set to run on the latest Ubuntu runner, checkout the code, set up JDK 22 with Temurin distribution, and execute Maven to package the project.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loiane/copilot-demo/issues/1?shareId=b0248d5c-2d29-47cc-9727-743da2d03ba3).