### PR TITLE
Replace javax with jakarta in imports

### DIFF
--- a/src/main/java/com/loiane/copilotdemo/model/Product.java
+++ b/src/main/java/com/loiane/copilotdemo/model/Product.java
@@ -1,13 +1,13 @@
 package com.loiane.copilotdemo.model;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 
 @Entity


### PR DESCRIPTION
Related to #6

Updates references from `javax.*` to `jakarta.*` in `Product.java`.

- Replaces `javax.persistence.*` and `javax.validation.constraints.*` imports with their `jakarta.persistence.*` and `jakarta.validation.constraints.*` counterparts.
- Ensures that the application aligns with the latest Jakarta EE specifications by updating package references.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loiane/copilot-demo/issues/6?shareId=97c62511-0859-4b0b-ac70-185a52ce6c54).