### PR TITLE
Fix compilation errors in tests

### DIFF
--- a/src/test/java/com/loiane/copilotdemo/CopilotDemoApplicationTests.java
+++ b/src/test/java/com/loiane/copilotdemo/CopilotDemoApplicationTests.java
@@ -18,8 +18,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.loiane.copilotdemo.model.Product;
-import com.loiane.copilotdemo.service.ProductService;
+import com.loiane.copilotdemo.product.Product;
+import com.loiane.copilotdemo.product.ProductService;
 
 @SpringBootTest
 @AutoConfigureMockMvc


### PR DESCRIPTION
Closed #11

Fixes compilation errors in `CopilotDemoApplicationTests.java` by correcting package imports.

- Replaces incorrect imports `com.loiane.copilotdemo.model` and `com.loiane.copilotdemo.service` with the correct `com.loiane.copilotdemo.product` package.
- Ensures all references to `Product` and `ProductService` classes are correctly resolved with the new import.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/loiane/copilot-demo/issues/11?shareId=e6661781-4afb-485e-9a1d-e34f63a4d6cf).